### PR TITLE
Fix command.config.rolesRequired.length bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -234,13 +234,11 @@ client.on('message', async (message) => {
 
     let isContentNull = false;
 
-    command.config.rolesRequired.forEach(function(value, _) {
-        if (value === null) {
-            isContentNull = true
-        };
-    })
+    function isContentNull(array) {
+        return array.some(v => v === null);
+    }
 
-    if(isContentNull = false && command.config.rolesRequired.length > 0) {
+    if(isContentNull === false) {
         if(!message.member.roles.cache.some(role => command.config.rolesRequired.includes(role.name))) {
             let embed = new Discord.MessageEmbed();
             embed.setDescription('You do not have permission to use this command.');

--- a/src/index.js
+++ b/src/index.js
@@ -235,7 +235,7 @@ client.on('message', async (message) => {
     let isContentNull = false;
 
     function isContentNull(array) {
-        return array.some(v => v === null);
+        isContentNull = array.some(v => v === null);
     }
 
     if(isContentNull === false) {

--- a/src/index.js
+++ b/src/index.js
@@ -232,7 +232,15 @@ client.on('message', async (message) => {
     const command = commandList.find((cmd) => cmd.name === commandName || cmd.config.aliases.includes(commandName));
     if(!command) return;
 
-    if(command.config.rolesRequired.length > 0) {
+    let isContentNull = false;
+
+    command.config.rolesRequired.forEach(function(value, _) {
+        if (value === null) {
+            isContentNull = true
+        };
+    })
+
+    if(isContentNull = false && command.config.rolesRequired.length > 0) {
         if(!message.member.roles.cache.some(role => command.config.rolesRequired.includes(role.name))) {
             let embed = new Discord.MessageEmbed();
             embed.setDescription('You do not have permission to use this command.');


### PR DESCRIPTION
The `command.config.rolesRequired.length` check could possibly break if the array is empty, another check added