### PR TITLE
Node.js v16

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,1 +1,2 @@
 run = "node src/index.js"
+language = "nix"

--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,5 @@
+{ pkgs }: {
+	deps = [
+        pkgs.nodejs-16_x
+	];
+}


### PR DESCRIPTION
The current method of getting Node.js v16 on Repl doesn't seem to work, however this should. 