### PR TITLE
replit.nix - Make repls work with node v16

### DIFF
--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,5 @@
+{ pkgs }: {
+	deps = [
+    pkgs.nodejs-16_x
+	];
+}


### PR DESCRIPTION
Make repls work with node v16 by having it download it first, it will add support for people to host qbot on repl.