### PR TITLE
Roles Fix

### DIFF
--- a/src/commands/information/roles.ts
+++ b/src/commands/information/roles.ts
@@ -14,8 +14,37 @@ class RolesCommand extends Command {
     }
 
     async run(ctx: CommandContext) {
-        const roles = await robloxGroup.getRoles();
-        return ctx.reply({ embeds: [ getRoleListEmbed(roles) ] });
+        try {
+            const roles = await robloxGroup.getRoles();
+
+            if (roles.length === 0) {
+                return ctx.reply({ content: 'No roles found in the group.', ephemeral: true });
+            }
+
+            const embeds = [];
+            const chunkSize = 25;
+            const firstChunk = roles.slice(0, chunkSize);
+            const firstEmbed = getRoleListEmbed(firstChunk);
+            embeds.push(firstEmbed);
+
+            for (let i = chunkSize; i < roles.length; i += chunkSize) {
+                const rolesChunk = roles.slice(i, i + chunkSize);
+                const embed = getRoleListEmbed(rolesChunk);
+
+                embed.setTitle(null); 
+                embed.setDescription(null); 
+
+                embeds.push(embed);
+            }
+
+            // Send the embeds in reply
+            for (const embed of embeds) {
+                await ctx.reply({ embeds: [embed] });
+            }
+        } catch (error) {
+            console.error('Error fetching roles:', error);
+            return ctx.reply({ content: 'An error occurred while fetching the roles. Please contact ZADMIN support', ephemeral: true });
+        }
     }
 }
 


### PR DESCRIPTION
If your group has over 25 ranks, this command will error and crash the bot. This is because Discord only allows 25 items, with this fix, it will send a separate embed to list the rest.